### PR TITLE
make it work on OS X

### DIFF
--- a/examples/minimal/minimal.nim
+++ b/examples/minimal/minimal.nim
@@ -1,4 +1,4 @@
-import webview
+import ../../webview
 
 proc test(sequ: cstring, req:cstring) = 
     var stvalue: string = $sequ

--- a/examples/minimal/minimal.nim
+++ b/examples/minimal/minimal.nim
@@ -1,4 +1,4 @@
-import ../../webview
+import webview
 
 proc test(sequ: cstring, req:cstring) = 
     var stvalue: string = $sequ

--- a/webview/webview.h
+++ b/webview/webview.h
@@ -591,9 +591,9 @@ using browser_engine = gtk_webkit_engine;
 namespace webview {
 
 // Helpers to avoid too much typing
-static id operator"" _cls(const char *s, std::size_t) { return (id)objc_getClass(s); }
-static SEL operator"" _sel(const char *s, std::size_t) { return sel_registerName(s); }
-static id operator"" _str(const char *s, std::size_t) {
+static inline id operator"" _cls(const char *s, std::size_t) { return (id)objc_getClass(s); }
+static inline SEL operator"" _sel(const char *s, std::size_t) { return sel_registerName(s); }
+static inline id operator"" _str(const char *s, std::size_t) {
   return ((id(*)(id, SEL, const char *))objc_msgSend)(
       "NSString"_cls, "stringWithUTF8String:"_sel, s);
 }

--- a/webview/webview.h
+++ b/webview/webview.h
@@ -25,7 +25,7 @@
 #define WEBVIEW_H
 
 #ifndef WEBVIEW_API
-#define WEBVIEW_API extern inline
+#define WEBVIEW_API extern inline 
 #endif
 
 #ifdef __cplusplus
@@ -591,9 +591,9 @@ using browser_engine = gtk_webkit_engine;
 namespace webview {
 
 // Helpers to avoid too much typing
-id operator"" _cls(const char *s, std::size_t) { return (id)objc_getClass(s); }
-SEL operator"" _sel(const char *s, std::size_t) { return sel_registerName(s); }
-id operator"" _str(const char *s, std::size_t) {
+inline id operator"" _cls(const char *s, std::size_t) { return (id)objc_getClass(s); }
+inline SEL operator"" _sel(const char *s, std::size_t) { return sel_registerName(s); }
+inline id operator"" _str(const char *s, std::size_t) {
   return ((id(*)(id, SEL, const char *))objc_msgSend)(
       "NSString"_cls, "stringWithUTF8String:"_sel, s);
 }

--- a/webview/webview.h
+++ b/webview/webview.h
@@ -591,9 +591,9 @@ using browser_engine = gtk_webkit_engine;
 namespace webview {
 
 // Helpers to avoid too much typing
-inline id operator"" _cls(const char *s, std::size_t) { return (id)objc_getClass(s); }
-inline SEL operator"" _sel(const char *s, std::size_t) { return sel_registerName(s); }
-inline id operator"" _str(const char *s, std::size_t) {
+static id operator"" _cls(const char *s, std::size_t) { return (id)objc_getClass(s); }
+static SEL operator"" _sel(const char *s, std::size_t) { return sel_registerName(s); }
+static id operator"" _str(const char *s, std::size_t) {
   return ((id(*)(id, SEL, const char *))objc_msgSend)(
       "NSString"_cls, "stringWithUTF8String:"_sel, s);
 }

--- a/webview/webview.h
+++ b/webview/webview.h
@@ -25,7 +25,7 @@
 #define WEBVIEW_H
 
 #ifndef WEBVIEW_API
-#define WEBVIEW_API extern inline 
+#define WEBVIEW_API extern inline
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
static inline rather than static or inline (all work) because https://stackoverflow.com/questions/48020778/duplicate-symbol-when-including-header-only-library-more-than-once said so